### PR TITLE
Fix async warnings

### DIFF
--- a/custom_components/climate_ip/climate.py
+++ b/custom_components/climate_ip/climate.py
@@ -258,7 +258,7 @@ class ClimateIP(ClimateEntity):
     async def async_update(self):
         time.sleep(self._update_delay)
         _LOGGER.info("async_update")
-        self.rac.update_state()
+        await self.hass.async_add_executor_job(self.rac.update_state())
 
     @property
     def temperature_unit(self):


### PR DESCRIPTION
This fixes all but one async warnings - i think there's one more sync-in-async call in async_setup_platform, but I can't really track it down, and this fixes the spam that people are complaining about in #1 
This component should really be rewritten to use aiohttp anyway