### PR TITLE
Reduce log level for connection errors

### DIFF
--- a/custom_components/climate_ip/samsung_2878.py
+++ b/custom_components/climate_ip/samsung_2878.py
@@ -229,11 +229,11 @@ class ConnectionSamsung2878(Connection):
                 self.handle_socket_response(sslSocket)
             self.logger.info("Handling finished")
         except:
-            self.logger.error("Sending command failed")
+            self.logger.info("Sending command failed")
             if sslSocket is not None:
                 sslSocket.close()
                 self._cfg.socket = None
-            self.logger.error(traceback.format_exc())
+            self.logger.info(traceback.format_exc())
 
         if not command_sent and retries > 0:
             self.logger.info("Retrying sending command...")


### PR DESCRIPTION
Reduce log level from "error" to "info" for connection errors with samsung 2878 AC.
As discussed in #5