### PR TITLE
Rename async_update to just update

### DIFF
--- a/custom_components/climate_ip/climate.py
+++ b/custom_components/climate_ip/climate.py
@@ -255,9 +255,9 @@ class ClimateIP(ClimateEntity):
             attrs[ATTR_NAME] = self._name
         return attrs
 
-    def async_update(self):
+    def update(self):
         time.sleep(self._update_delay)
-        _LOGGER.info("async_update")
+        _LOGGER.info("update")
         self.rac.update_state()
 
     @property


### PR DESCRIPTION
Since updates are now performed in blocking context as opposed to
async context, there should not be async_ in the name.

Relates to #20.