### PR TITLE
Temperature range

### DIFF
--- a/custom_components/climate_ip/climate.py
+++ b/custom_components/climate_ip/climate.py
@@ -90,8 +90,8 @@ REQUIREMENTS = ["requests>=2.21.0", "xmljson>=0.2.0"]
 
 CLIMATE_IP_DATA = "climate_ip_data"
 ENTITIES = "entities"
-DEFAULT_CLIMATE_IP_TEMP_MIN = 16
-DEFAULT_CLIMATE_IP_TEMP_MAX = 32
+DEFAULT_CLIMATE_IP_TEMP_MIN = 8
+DEFAULT_CLIMATE_IP_TEMP_MAX = 30
 DEFAULT_UPDATE_DELAY = 1.5
 SERVICE_SET_CUSTOM_OPERATION = "climate_ip_set_property"
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/climate_ip/samsung_2878.yaml
+++ b/custom_components/climate_ip/samsung_2878.yaml
@@ -96,8 +96,8 @@ device:
       validation_template: '{% if "AC_FUN_DIRECTION" in device_state %}valid{% endif %}'
     temperature:
       type: number
-      min: 16
-      max: 32
+      min: 8
+      max: 30
       status_template: '{% for key, value in device_state.items() %}{% if key == "AC_FUN_TEMPSET" %}{{value}}{% endif %}{% endfor %}'
       connection_template: '<Request Type="DeviceControl"><Control CommandID="AC_FUN_TEMPSET" DUID="{{duid}}"><Attr ID="AC_FUN_TEMPSET" Value="{{value}}" /></Control></Request>'
   attributes:
@@ -106,10 +106,10 @@ device:
       status_template: '{% for key, value in device_state.items() %}{% if key == "AC_FUN_TEMPNOW" %}{{value}}{% endif %}{% endfor %}'
     min_temp:
       type: number
-      status_template: '16'
+      status_template: '8'
     max_temp:
       type: number
-      status_template: '32'
+      status_template: '30'
   used_power:
     type: number
     status_template: '{% for key, value in device_state.items() %}{% if key == "AC_ADD2_USEDPOWER" %}{{value}}{% endif %}{% endfor %}'

--- a/custom_components/climate_ip/samsungrac.yaml
+++ b/custom_components/climate_ip/samsungrac.yaml
@@ -126,7 +126,7 @@ device:
       type: number
       connection:
         params: { method: 'PUT', url: 'https://__CLIMATE_IP_HOST__:8888/devices/0/temperatures/0' }
-      min: 16
+      min: 8
       max: 30
       status_template: '{{ device_state.Devices.0.Temperatures.0.desired | int }}'
       connection_template: '{ "json": { "desired": {{ value | int }} } }'
@@ -138,7 +138,7 @@ device:
       unit_template: '{{ device_state.Devices.0.Temperatures.0.unit }}'
     min_temp:
       type: number
-      status_template: '16'
+      status_template: '8'
       unit_template: '{{ device_state.Devices.0.Temperatures.0.unit }}'
     max_temp:
       type: number


### PR DESCRIPTION
First of all, thank you for maintaining this. I have several locations with Samsung AC / Home Assistant, and it's great to be able to control everything from one system.

This change applies to temperature range. Samsung AC supports temperatures between 8-30 degrees. Applies to both RAC and 2878. I have both types myself and have tested it. I often need to adjust the temperature down to 10 degrees when I am away traveling, since I use it for heating.