### PR TITLE
Finishing the MIM-H03 template

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,15 @@ https://github.com/SebuZet/samsungrac
     | name      | Device name (by default this value is taken from YAML config file) | No
     | controller    | Controller type to use (default, and the only one for now: yaml)  | No
     | poll      | Enable/disable state polling. Default: Taken from YAML config. Enabled for old gen devices | No
+    | device_id | Set the device for controllers like MIM-H03, which can control multiple air con units | No. Strongly recommended for MIM-H03. Defaults to `032000000`
     | debug      | Enable/disable more debugs. Default: False | No
 2. You need to have your device __token__. I will create a guide to gather it
-2. YAML configuration
+3. If you're using MIM-H03, you may need your device ID, this can be had by running the following command and select your aircon device. It might be device `0`.
+```sh
+curl -k -H "Content-Type: application/json" -H "Authorization: Bearer __DEVICE_TOKEN__" --cert ac14k_m.pem -X GET https://__CLIMATE_IP_HOST__:8888/devices/
+```
+
+4. YAML configuration
 You can easily add, remove or modify any device paramter to meet device capabilities.
 
 ## YAML configuration file syntax

--- a/custom_components/climate_ip/climate.py
+++ b/custom_components/climate_ip/climate.py
@@ -65,6 +65,7 @@ from .yaml_const import (
     CONF_CONFIG_FILE,
     CONF_CONTROLLER,
     CONF_DEBUG,
+    CONF_DEVICE_ID,
     CONFIG_DEVICE_NAME,
     CONFIG_DEVICE_POLL,
     CONFIG_DEVICE_UPDATE_DELAY,
@@ -111,6 +112,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(
             CONFIG_DEVICE_UPDATE_DELAY, default=DEFAULT_UPDATE_DELAY
         ): cv.string,
+        vol.Optional(CONF_DEVICE_ID, default='032000000'): cv.string,
     }
 )
 
@@ -124,8 +126,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         device_controller = create_controller(
             config.get(CONF_CONTROLLER), config, _LOGGER
         )
-    except:
+    except Exception as e:
         _LOGGER.error("climate_ip: error while creating controller!")
+        import traceback
+        _LOGGER.error(traceback.format_exc())
+        _LOGGER.error(e)
         raise
 
     if device_controller is None:
@@ -186,6 +191,7 @@ class ClimateIP(ClimateEntity):
         self.rac = rac_controller
         self._name = config.get(CONFIG_DEVICE_NAME, None)
         self._poll = None
+        self._unique_id = None
         str_poll = config.get(CONFIG_DEVICE_POLL, "")
         if str_poll:
             str_poll = str_poll.lower()
@@ -236,6 +242,15 @@ class ClimateIP(ClimateEntity):
             res = self.rac.poll
         _LOGGER.info("Should poll: {}".format(res))
         return res
+
+    @property
+    def unique_id(self):
+        if self._unique_id is None and self.rac.unique_id is not None:
+            _LOGGER.info("About to set unique id {}".format(self.rac.unique_id))
+            self._unique_id = "climate_ip_" + self.rac.unique_id
+        
+        _LOGGER.info("Returning unique id of {}".format(self._unique_id))
+        return self._unique_id
 
     @property
     def name(self):

--- a/custom_components/climate_ip/controller_yaml.py
+++ b/custom_components/climate_ip/controller_yaml.py
@@ -30,6 +30,7 @@ from .yaml_const import (
     CONFIG_DEVICE_OPERATIONS,
     CONFIG_DEVICE_POLL,
     CONFIG_DEVICE_STATUS,
+    CONFIG_DEVICE_UNIQUE_ID,
     CONFIG_DEVICE_VALIDATE_PROPS,
 )
 
@@ -86,10 +87,16 @@ class YamlController(ClimateController):
         self._retries_count = 0
         self._last_device_state = None
         self._poll = None
+        self._unique_id = None
+        self._uniqe_id_prop = None
 
     @property
     def poll(self):
         return self._poll
+    
+    @property
+    def unique_id(self):
+        return self._unique_id
 
     @property
     def id(self):
@@ -163,6 +170,10 @@ class YamlController(ClimateController):
                 prop = create_property(key, nodes[key], connection)
                 if prop is not None:
                     self._properties[prop.id] = prop
+            
+            unique_id_prop = create_property(CONFIG_DEVICE_UNIQUE_ID, ac.get(CONFIG_DEVICE_UNIQUE_ID, {}), connection)
+            if unique_id_prop is not None:
+                self._uniqe_id_prop = unique_id_prop
 
             self._name = ac.get(ATTR_NAME, CONST_CONTROLLER_TYPE)
 
@@ -225,6 +236,8 @@ class YamlController(ClimateController):
             for prop in self._properties.values():
                 prop.update_state(device_state, debug)
                 self._attributes.update(prop.state_attributes)
+            if self._unique_id is None and self._uniqe_id_prop is not None:
+                self._unique_id = self._uniqe_id_prop.update_state(device_state, debug)
 
     def set_property(self, property_name, new_value):
         print("SETTING UP property {} to {}".format(property_name, new_value))

--- a/custom_components/climate_ip/mim-h03_heatpump.yaml
+++ b/custom_components/climate_ip/mim-h03_heatpump.yaml
@@ -21,11 +21,13 @@ device:
       connection:
         params: { method: 'PUT', url: 'https://__CLIMATE_IP_HOST__:8888/devices/032001000/mode' }
       values:
-        'cool': { value : 'Opmode_Cool', connection: { params: { json: { "Operation": { "power" : "On" }, "Mode": { "modes": ["Opmode_Cool"] } } } } }
-        'heat': { value : 'Opmode_Heat', connection: { params: { json: { "Operation": { "power" : "On" }, "Mode": { "modes": ["Opmode_Heat"] } } } } }
+        cool: { value : 'Opmode_Cool', connection: { params: { json: { "Operation": { "power" : "On" }, "Mode": { "modes": ["Opmode_Cool"] } } } } }
+        heat: { value : 'Opmode_Heat', connection: { params: { json: { "Operation": { "power" : "On" }, "Mode": { "modes": ["Opmode_Heat"] } } } } }
         'off': { value: 'Off', connection: { params: { json: { "Operation": { "power" : "Off" } } } } }
-        # When switched to "Auto" mode the controller refuses to accept a temperature set command. For this reason the auto command is disabled
-        # auto: { value : 'Opmode_Auto', connection: { params: { json: { "Operation": { "power" : "On" }, "Mode": { "modes": ["Opmode_Auto"] } } } } }
+        auto: { value : 'Opmode_Auto', connection: { params: { json: { "Operation": { "power" : "On" }, "Mode": { "modes": ["Opmode_Auto"] } } } } }
+        heat_cool: { value : 'Opmode_Auto', connection: { params: { json: { "Operation": { "power" : "On" }, "Mode": { "modes": ["Opmode_Auto"] } } } } }
+        fan_only: { value : 'Opmode_Fan', connection: { params: { json: { "Operation": { "power" : "On" }, "Mode": { "modes": ["Opmode_Fan"] } } } } }
+        dry: { value : 'Opmode_Dry', connection: { params: { json: { "Operation": { "power" : "On" }, "Mode": { "modes": ["Opmode_Dry"] } } } } }
       status_template: "{% if device_state.Operation.power == 'Off' -%}Off{%- elif device_state.Operation.power == 'On' -%}{{ device_state.Mode.modes.0 }}{%- endif %}"
     power:
       type: switch
@@ -43,6 +45,17 @@ device:
         'off': { value: 'Volume_Mute', connection: { params: { json: { "options": [ "Volume_Mute"] } } } }
         'on': { value: 'Volume_100', connection: { params: { json: { "options": [ "Volume_100"] } } } }
       status_template: '{{ device_state.Mode.options.0 }}'
+    fan: # fan_mode
+      type: modes
+      connection:
+        params: { method: 'PUT', url: 'https://__CLIMATE_IP_HOST__:8888/devices/032001000/wind' }
+      values:
+        # For some reason, the values a bit opposite
+        'Auto': { value : '0', connection: { params: { json: { "Wind": { "speedLevel": 0 } } } } }
+        'Low': { value : '4', connection: { params: { json: { "Wind": { "speedLevel": 4 } } } } }
+        'Medium': { value : '3', connection: { params: { json: { "Wind": { "speedLevel": 3 } } } } }
+        'High': { value : '2', connection: { params: { json: { "Wind": { "speedLevel": 2 } } } } }
+      status_template: '{{ device_state.Wind.speedLevel }}'
     temperature:
       type: number
       connection:
@@ -64,3 +77,4 @@ device:
     max_temp:
       type: number
       status_template: '{{ device_state.Temperatures.0.maximum }}'
+

--- a/custom_components/climate_ip/mim-h03_heatpump.yaml
+++ b/custom_components/climate_ip/mim-h03_heatpump.yaml
@@ -3,6 +3,7 @@
 # Use the following command to determine the appropriate device ID and adjust accordingly the params
 #   curl -v -k -H "Content-Type: application/json" -H "Authorization: Bearer __CLIMATE_IP_TOKEN__" --cert ac14k_m.pem -X GET https://__CLIMATE_IP_HOST__:8888/devices/
 device:
+  poll: true
   name: 'mim-h03_heatpump'
   connection:
     type: request
@@ -18,7 +19,7 @@ device:
     hvac: # hvac_mode
       type: modes
       connection:
-        params: { method: 'PUT', url: 'https://__CLIMATE_IP_HOST__:8888/devices/032000000/mode' }
+        params: { method: 'PUT', url: 'https://__CLIMATE_IP_HOST__:8888/devices/032001000/mode' }
       values:
         'cool': { value : 'Opmode_Cool', connection: { params: { json: { "Operation": { "power" : "On" }, "Mode": { "modes": ["Opmode_Cool"] } } } } }
         'heat': { value : 'Opmode_Heat', connection: { params: { json: { "Operation": { "power" : "On" }, "Mode": { "modes": ["Opmode_Heat"] } } } } }
@@ -26,18 +27,18 @@ device:
         # When switched to "Auto" mode the controller refuses to accept a temperature set command. For this reason the auto command is disabled
         # auto: { value : 'Opmode_Auto', connection: { params: { json: { "Operation": { "power" : "On" }, "Mode": { "modes": ["Opmode_Auto"] } } } } }
       status_template: "{% if device_state.Operation.power == 'Off' -%}Off{%- elif device_state.Operation.power == 'On' -%}{{ device_state.Mode.modes.0 }}{%- endif %}"
-#    power:
-#      type: switch
-#      connection:
-#        params: { method: 'PUT', url: 'https://__CLIMATE_IP_HOST__:8888/devices/032000000/operation' }
-#      values:
-#        'off': { value: 'Off', connection: { params: { json: { "Operation": { "power" : "Off" } } } } }
-#        'on': { value: 'On', connection: { params: { json: { "Operation": { "power" : "On" } } } } }
-#      status_template: '{{ device_state.Operation.power }}'
+    power:
+      type: switch
+      connection:
+        params: { method: 'PUT', url: 'https://__CLIMATE_IP_HOST__:8888/devices/032001000/operation' }
+      values:
+        'off': { value: 'Off', connection: { params: { json: { "Operation": { "power" : "Off" } } } } }
+        'on': { value: 'On', connection: { params: { json: { "Operation": { "power" : "On" } } } } }
+      status_template: '{{ device_state.Operation.power }}'
     beep:
       type: switch
       connection:
-        params: { method: 'PUT', url: 'https://__CLIMATE_IP_HOST__:8888/devices/032000000/mode' }
+        params: { method: 'PUT', url: 'https://__CLIMATE_IP_HOST__:8888/devices/032001000/mode' }
       values:
         'off': { value: 'Volume_Mute', connection: { params: { json: { "options": [ "Volume_Mute"] } } } }
         'on': { value: 'Volume_100', connection: { params: { json: { "options": [ "Volume_100"] } } } }
@@ -45,7 +46,7 @@ device:
     temperature:
       type: number
       connection:
-        params: { method: 'PUT', url: 'https://__CLIMATE_IP_HOST__:8888/devices/032000000/temperatures/0' }
+        params: { method: 'PUT', url: 'https://__CLIMATE_IP_HOST__:8888/devices/032001000/temperatures/0' }
       min: 16
       max: 55
       status_template: '{{ device_state.Temperatures.0.desired | int }}'
@@ -54,9 +55,9 @@ device:
     current_temperature:
       type: number
       status_template: '{{ device_state.Temperatures.0.current }}'
-    current_outside_temperature:
+    target_temperature:
       type: number
-      status_template: '{{ device_state.Temperatures.2.current }}'
+      status_template: '{{ device_state.Temperatures.0.desired }}'
     min_temp:
       type: number
       status_template: '{{ device_state.Temperatures.0.minimum }}'

--- a/custom_components/climate_ip/mim-h03_heatpump.yaml
+++ b/custom_components/climate_ip/mim-h03_heatpump.yaml
@@ -5,6 +5,9 @@
 device:
   poll: true
   name: 'mim-h03_heatpump'
+  unique_id:
+    type: string
+    status_template: '{{ device_state.uuid }}'
   connection:
     type: request
     params: 
@@ -77,4 +80,3 @@ device:
     max_temp:
       type: number
       status_template: '{{ device_state.Temperatures.0.maximum }}'
-

--- a/custom_components/climate_ip/mim-h03_heatpump.yaml
+++ b/custom_components/climate_ip/mim-h03_heatpump.yaml
@@ -22,7 +22,7 @@ device:
     hvac: # hvac_mode
       type: modes
       connection:
-        params: { method: 'PUT', url: 'https://__CLIMATE_IP_HOST__:8888/devices/032001000/mode' }
+        params: { method: 'PUT', url: 'https://__CLIMATE_IP_HOST__:8888/devices/__DEVICE_ID__/mode' }
       values:
         cool: { value : 'Opmode_Cool', connection: { params: { json: { "Operation": { "power" : "On" }, "Mode": { "modes": ["Opmode_Cool"] } } } } }
         heat: { value : 'Opmode_Heat', connection: { params: { json: { "Operation": { "power" : "On" }, "Mode": { "modes": ["Opmode_Heat"] } } } } }
@@ -35,7 +35,7 @@ device:
     power:
       type: switch
       connection:
-        params: { method: 'PUT', url: 'https://__CLIMATE_IP_HOST__:8888/devices/032001000/operation' }
+        params: { method: 'PUT', url: 'https://__CLIMATE_IP_HOST__:8888/devices/__DEVICE_ID__/operation' }
       values:
         'off': { value: 'Off', connection: { params: { json: { "Operation": { "power" : "Off" } } } } }
         'on': { value: 'On', connection: { params: { json: { "Operation": { "power" : "On" } } } } }
@@ -43,7 +43,7 @@ device:
     beep:
       type: switch
       connection:
-        params: { method: 'PUT', url: 'https://__CLIMATE_IP_HOST__:8888/devices/032001000/mode' }
+        params: { method: 'PUT', url: 'https://__CLIMATE_IP_HOST__:8888/devices/__DEVICE_ID__/mode' }
       values:
         'off': { value: 'Volume_Mute', connection: { params: { json: { "options": [ "Volume_Mute"] } } } }
         'on': { value: 'Volume_100', connection: { params: { json: { "options": [ "Volume_100"] } } } }
@@ -51,7 +51,7 @@ device:
     fan: # fan_mode
       type: modes
       connection:
-        params: { method: 'PUT', url: 'https://__CLIMATE_IP_HOST__:8888/devices/032001000/wind' }
+        params: { method: 'PUT', url: 'https://__CLIMATE_IP_HOST__:8888/devices/__DEVICE_ID__/wind' }
       values:
         # For some reason, the values a bit opposite
         'Auto': { value : '0', connection: { params: { json: { "Wind": { "speedLevel": 0 } } } } }
@@ -62,7 +62,7 @@ device:
     temperature:
       type: number
       connection:
-        params: { method: 'PUT', url: 'https://__CLIMATE_IP_HOST__:8888/devices/032001000/temperatures/0' }
+        params: { method: 'PUT', url: 'https://__CLIMATE_IP_HOST__:8888/devices/__DEVICE_ID__/temperatures/0' }
       min: 16
       max: 55
       status_template: '{{ device_state.Temperatures.0.desired | int }}'

--- a/custom_components/climate_ip/properties.py
+++ b/custom_components/climate_ip/properties.py
@@ -27,6 +27,7 @@ from .yaml_const import (
 CLIMATE_IP_PROPERTIES = []
 CLIMATE_IP_STATUS_GETTER = []
 
+PROPERTY_TYPE_STRING = "string"
 PROPERTY_TYPE_MODE = "modes"
 PROPERTY_TYPE_SWITCH = "switch"
 PROPERTY_TYPE_NUMBER = "number"
@@ -368,6 +369,15 @@ class ModeOperation(BasicDeviceOperation):
         data[self.id] = self.value
         data[self.name + "_modes"] = self.values
         return data
+
+@register_property
+class UniqueIdProperty(DeviceProperty):
+    def __init__(self, name, connection):
+        super().__init__(name, connection)
+
+    @staticmethod
+    def match_type(type):
+        return type == PROPERTY_TYPE_STRING
 
 
 @register_property

--- a/custom_components/climate_ip/yaml_const.py
+++ b/custom_components/climate_ip/yaml_const.py
@@ -24,6 +24,7 @@ CONFIG_DEVICE_POWER_TEMPLATE = "power_template"
 CONF_CERT = "cert"
 CONF_DEBUG = "debug"
 CONF_CONTROLLER = "controller"
+CONF_DEVICE_ID = "device_id"
 
 DEFAULT_CONF_CONFIG_FILE = "samsungrac.yaml"
 CONF_CONFIG_FILE = "config_file"

--- a/custom_components/climate_ip/yaml_const.py
+++ b/custom_components/climate_ip/yaml_const.py
@@ -1,6 +1,7 @@
 CONFIG_DEVICE = "device"
 CONFIG_DEVICE_NAME = "name"
 CONFIG_DEVICE_POLL = "poll"
+CONFIG_DEVICE_UNIQUE_ID = "unique_id"
 CONFIG_DEVICE_UPDATE_DELAY = "update_delay"
 CONFIG_DEVICE_VALIDATE_PROPS = "validate_properties"
 CONFIG_DEVICE_CONNECTION = "connection"


### PR DESCRIPTION
A few things are happening in this PR

- Moving async calls off to another thread. This is a requirement in the newer versions of HA. The preferred method is to use async-await but that is going to take a lot more effort to fix. In the mean time, I'm making use of a thread pool executor to move async calls off the main even thread
- Completed the MIM-H03 template
- Added a "device unique id" field to make it easier to manage from the UI
- MIM-H03 can actually manage multiple air-cons. I've added a device id param so that you can describe the device ID you want to control. Then you can use multiple devices on this integration. In my case, my device id was different for some reason.
- Set the MIM-H03 to polling mode

Other decides are going to have to support the unique id too. Null values wont break the integration but someone with those devices who can test those changes are welcome to do so.