### PR TITLE
SSL error logging and cipher fix

### DIFF
--- a/custom_components/climate_ip/connection_request.py
+++ b/custom_components/climate_ip/connection_request.py
@@ -131,8 +131,7 @@ class ConnectionRequestBase(Connection):
                 try:
                     resp = future.result()
                 except:
-                    self.logger.info("Request result exception. Exception:")
-                    self.logger.info(future.exception())
+                    self.logger.error("Request result exception: {}".format(future.exception()))
                     return (None, False, 0)
 
                 self.logger.info(

--- a/custom_components/climate_ip/samsung_2878.py
+++ b/custom_components/climate_ip/samsung_2878.py
@@ -245,7 +245,7 @@ class ConnectionSamsung2878(Connection):
         self.logger.info("Creating ssl context")
         sslContext = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
         self.logger.info("Setting up ciphers")
-        sslContext.set_ciphers("HIGH:!DH:!aNULL")
+        sslContext.set_ciphers("ALL:@SECLEVEL=0")
         self.logger.info("Setting up verify mode")
         sslContext.verify_mode = (
             ssl.CERT_REQUIRED if cfg.cert is not None else ssl.CERT_NONE


### PR DESCRIPTION
Fixed ciphers for 2878 devices and added error logging on connection request. This will show any errors related to the SSL certificates without debug logging turned on.

Issue #40 mentioned that some devices needs "HIGH:!DH:!aNULL" instead of "ALL:@SECLEVEL=0" but from my understanding this should not be an issue as it sets the security level to allow everything basically. I can't figure out why some units wouldn't work with this. If any more issues pop up with this we might have to add a configuration option for the ciphers.