### PR TITLE
Preset mode "Turbo" fix

### DIFF
--- a/custom_components/climate_ip/samsung_2878.yaml
+++ b/custom_components/climate_ip/samsung_2878.yaml
@@ -32,7 +32,7 @@ device:
         'Good Sleep': { value : 'Sleep' }
         'Single User': { value : 'Smart' }
         'Comfort': { value : 'SoftCool' }
-        'Fast Turbo': { value : 'WindMode3' }
+        'Fast Turbo': { value : 'TurboMode' }
       status_template: '{% for key, value in device_state.items() %}{% if key == "AC_FUN_COMODE" %}{{value}}{% endif %}{% endfor %}'
       connection_template: '<Request Type="DeviceControl"><Control CommandID="AC_FUN_COMODE" DUID="{{duid}}"><Attr ID="AC_FUN_COMODE" Value="{{value}}" /></Control></Request>'
       validation_template: '{% if "AC_FUN_COMODE" in device_state %}valid{% endif %}'


### PR DESCRIPTION
Fix of preset mode TURBO. After selecting it on remote i see the working name and this is "TurboMode" 
<img width="466" alt="Schermata 2022-07-24 alle 01 22 09" src="https://user-images.githubusercontent.com/79342944/180625916-4997628f-c944-4172-99a4-ef6d3b58e21f.png">
.