### PR TITLE
Update connection_request.py to accept TLSv1.0

### DIFF
--- a/custom_components/climate_ip/connection_request.py
+++ b/custom_components/climate_ip/connection_request.py
@@ -29,6 +29,7 @@ class SamsungHTTPAdapter(HTTPAdapter):
         ssl_context = ssl.create_default_context()
         ssl_context.check_hostname = False
         ssl_context.set_ciphers("ALL:@SECLEVEL=0")
+        ssl_context.minimum_version = ssl.TLSVersion.TLSv1
         kwargs["ssl_context"] = ssl_context
         return super().init_poolmanager(*args, **kwargs)
 


### PR DESCRIPTION
To resolve openssl unsupported protocol problem

ERROR (MainThread) [custom_components.climate_ip.climate] Request result exception: HTTPSConnectionPool(host='xxx.xxx.xxx.xxx', port=8888): Max retries exceeded with url: /devices (Caused by SSLError(SSLError(1, '[SSL: UNSUPPORTED_PROTOCOL] unsupported protocol (_ssl.c:1000)')))

Modification may need to be tested on different installs