### PR TITLE
Fix: Replace xmljson with xmltodict for HA 2025.6.x compatibility

### DIFF
--- a/custom_components/climate_ip/manifest.json
+++ b/custom_components/climate_ip/manifest.json
@@ -11,9 +11,7 @@
   "issue_tracker": "https://github.com/atxbyea/samsungrac/issues",
   "requirements": [
     "requests>=2.21.0",
-    "xmljson>=0.2.0"
+    "xmltodict>=0.13.0"
   ],
   "version": "3.5.2"
 }
-
-  


### PR DESCRIPTION
The **_xmljson_** library fails to install on **Home Assistant 2025.6.0** due to a "_Metadata field Name not found_" error. This prevents the integration from starting.

This commit replaces the dependency with **_xmltodict_**, resolving the installation issue and ensuring compatibility with the latest Home Assistant versions.