### PR TITLE
Fix dict returned from execute() causing "object dict can't be used i…

### DIFF
--- a/custom_components/climate_ip/properties.py
+++ b/custom_components/climate_ip/properties.py
@@ -1,4 +1,5 @@
 import json
+import inspect
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNKNOWN, UnitOfTemperature
@@ -189,10 +190,14 @@ class GetJsonStatus(DeviceProperty):
         Fetches the device state asynchronously.
         """
         self._device_state = device_state
-        # The execute method is now async, so we must await it
-        device_state_result = await self.get_connection(None).execute(
+        # execute() may be synchronous (returns dict) or asynchronous depending on the connection implementation.
+        # Only await the result when it is awaitable to support both cases.
+        res = self.get_connection(None).execute(
             self.connection_template, None, device_state
         )
+        if inspect.isawaitable(res):
+            res = await res
+        device_state_result = res
         
         self._value = device_state_result
         self._json_status = device_state_result
@@ -455,3 +460,4 @@ class TemperatureOperation(BasicNumericOperation):
         return TemperatureConverter.convert(
             float(v), UnitOfTemperature.CELSIUS, self._unit
         )
+


### PR DESCRIPTION
…n await expression"

Home Assistant 2025.7.x (Python 3.13) fails to load climate_ip with:

TypeError: object dict can't be used in 'await' expression

Root cause: get_connection().execute(...) may return a dict (sync) depending on connection type, but async_update_state always awaited it.

Fix: only await if the result is awaitable (inspect.isawaitable()). This keeps compatibility with async implementations while supporting sync ones.